### PR TITLE
force run of gc in weak ref test case

### DIFF
--- a/tests/test_weak.py
+++ b/tests/test_weak.py
@@ -1,9 +1,11 @@
+import gc
 from smoke import weak, Disconnect
 from tests.matchers import assert_raises
 from hamcrest import assert_that, equal_to, instance_of
 
 
 class Dummy(object):
+    value = None
     def spam(self):
         return self.value
 
@@ -20,6 +22,7 @@ def test_weak_raises_disconnect():
     d = Dummy()
     w = weak(d.spam)
     del d
+    gc.collect()
 
     with assert_raises(instance_of(Disconnect)):
         r = w()


### PR DESCRIPTION
pypy is not using reference counting and thus the weakref will not trigger
an error immediately unless a garbage collector run is done explicitly.
